### PR TITLE
Fixed exponentiation operator in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ List of supported rules
   - `es5/no-computed-properties`: Forbid [computed properties](https://babeljs.io/learn-es2015/#ecmascript-2015-features-enhanced-object-literals).
   - `es5/no-default-parameters`: Forbid [default parameters](https://babeljs.io/learn-es2015/#ecmascript-2015-features-default-rest-spread).
   - `es5/no-destructuring`: Forbid [destructuring statements](https://babeljs.io/learn-es2015/#ecmascript-2015-features-destructuring).
-  - `es5/exponentiation-operator`: Forbid exponentiation operator `a ** b` usage.
+  - `es5/no-exponentiation-operator`: Forbid exponentiation operator `a ** b` usage.
   - `es5/no-for-of`: Forbid [`for-of` statements](https://babeljs.io/learn-es2015/#ecmascript-2015-features-iterators-for-of).
   - `es5/no-generators`: Forbid [generators](https://babeljs.io/learn-es2015/#ecmascript-2015-features-generators) usage.
   - `es5/no-modules`: Forbid ES2015 [modules](https://babeljs.io/learn-es2015/#ecmascript-2015-features-modules) usage.


### PR DESCRIPTION
README mentions `es5/exponentiation-operator` which does not exist. Only `es5/no-exponentiation-operator` exists :).