### PR TITLE
[update] Make `es5/no-template-literals` fixable

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ List of supported rules
   - `es5/no-rest-parameters`: Forbid [rest parameters](https://babeljs.io/learn-es2015/#ecmascript-2015-features-default-rest-spread).
   - `es5/no-shorthand-properties`: Forbid [shorthand properties](https://babeljs.io/learn-es2015/#ecmascript-2015-features-enhanced-object-literals).
   - `es5/no-spread`: Forbid [...spread expressions](https://babeljs.io/learn-es2015/#ecmascript-2015-features-default-rest-spread).
-  - `es5/no-template-literals`: Forbid [template strings](https://babeljs.io/learn-es2015/#ecmascript-2015-features-template-strings) usage.
+  - `es5/no-template-literals`:wrench:: Forbid [template strings](https://babeljs.io/learn-es2015/#ecmascript-2015-features-template-strings) usage.
   - `es5/no-typeof-symbol`: Forbid `typeof foo === 'symbol'` [checks](https://babeljs.io/learn-es2015/#ecmascript-2015-features-symbols).
   - `es5/no-unicode-regex`: Forbid [Unicode support](https://babeljs.io/learn-es2015/#ecmascript-2015-features-unicode) in RegExp.
 

--- a/src/rules/no-template-literals.js
+++ b/src/rules/no-template-literals.js
@@ -5,14 +5,36 @@ module.exports = {
     docs: {
       description: 'Forbid template literals'
     },
+    fixable: 'code',
     schema: []
   },
   create(context) {
+    const sourceCode = context.getSourceCode()
     return {
       TemplateLiteral(node) {
         context.report({
           node,
-          message: 'Unexpected template-string expression.'
+          message: 'Unexpected template-string expression.',
+          fix(fixer) {
+            const ss = [];
+            node.quasis.forEach((q, i) => {
+              const value = q.value.raw
+              if (value !== '') {
+                const escaped = value.replace(`'`, `\\'`).replace('\\`', '`')
+                ss.push(`'${escaped}'`);
+              }
+              
+              if (i < node.expressions.length) {
+                const e = node.expressions[i]
+                const text = sourceCode.getText(e)
+                ss.push(text);
+              }
+            })
+            if (!ss[0] || ss[0].indexOf(`'`) !== 0) {
+              ss.unshift(`''`);
+            }
+            return fixer.replaceText(node, ss.join('+'))
+          }
         });
       }
     };

--- a/tests/rules/no-template-literals.js
+++ b/tests/rules/no-template-literals.js
@@ -6,7 +6,55 @@ module.exports = {
     '"test"'
   ],
   invalid: [
-    { code: '`test`', errors: [{ message: 'Unexpected template-string expression.' }] },
-    { code: '`test${foo}`', errors: [{ message: 'Unexpected template-string expression.' }] }
+    {
+      code: '`test`',
+      output: `'test'`,
+      errors: [{ message: 'Unexpected template-string expression.' }]
+    },
+    {
+      code: '`test${foo}`',
+      output: `'test'+foo`,
+      errors: [{ message: 'Unexpected template-string expression.' }]
+    },
+    {
+      code: '`test${foo()}`',
+      output: `'test'+foo()`,
+      errors: [{ message: 'Unexpected template-string expression.' }]
+    },
+    {
+      code: '`test${foo.bar}`',
+      output: `'test'+foo.bar`,
+      errors: [{ message: 'Unexpected template-string expression.' }]
+    },
+    {
+      code: '`test${1} test${2}`',
+      output: `'test'+1+' test'+2`,
+      errors: [{ message: 'Unexpected template-string expression.' }]
+    },
+    {
+      code: '`test${1}${2}`',
+      output: `'test'+1+2`,
+      errors: [{ message: 'Unexpected template-string expression.' }]
+    },
+    {
+      code: '`\'"`',// to escape test
+      output: `'\\'"'`,
+      errors: [{ message: 'Unexpected template-string expression.' }]
+    },
+    {
+      code: '`\\``',// escape code test
+      output: `'\`'`,
+      errors: [{ message: 'Unexpected template-string expression.' }]
+    },
+    {
+      code: '``',// empty
+      output: `''`,
+      errors: [{ message: 'Unexpected template-string expression.' }]
+    },
+    {
+      code: '`${1}${2}`',// expressions only
+      output: `''+1+2`,
+      errors: [{ message: 'Unexpected template-string expression.' }]
+    }
   ]
 };


### PR DESCRIPTION
This PR makes `es5/no-template-literals` fixable.
The autofix transforms template-literals to string concatenation.