### PR TITLE
[update] Make `es5/no-arrow-functions` fixable

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Available presets:
 List of supported rules
 -----------------------
 
-  - `es5/no-arrow-functions`: Forbid [arrow-functions](https://babeljs.io/learn-es2015/#ecmascript-2015-features-arrows-and-lexical-this).
+  - `es5/no-arrow-functions`:wrench:: Forbid [arrow-functions](https://babeljs.io/learn-es2015/#ecmascript-2015-features-arrows-and-lexical-this).
   - `es5/no-block-scoping`: Forbid `let` and `const` declarations. You can enable them using options: `"es5/no-block-scoping": ["error", { "let": true }]`
   - `es5/no-classes`: Forbid [ES2015 classes](https://babeljs.io/learn-es2015/#ecmascript-2015-features-classes).
   - `es5/no-computed-properties`: Forbid [computed properties](https://babeljs.io/learn-es2015/#ecmascript-2015-features-enhanced-object-literals).

--- a/src/rules/no-arrow-functions.js
+++ b/src/rules/no-arrow-functions.js
@@ -1,18 +1,40 @@
 'use strict';
 
+function toFunctionExpression(node, sourceCode) {
+  const params = node.params;
+  const paramText = params.length ?
+    sourceCode.text.slice(params[0].range[0], params[params.length - 1].range[1]) :
+    ''
+
+  const bodyText = sourceCode.getText(node.body)
+  if (node.body.type === 'BlockStatement') {
+    return `function(${paramText})${bodyText}`;
+  } else {
+    return `function(${paramText}){return ${bodyText}}`;
+  }
+}
+
 module.exports = {
   meta: {
     docs: {
       description: 'Forbid arrow-functions'
     },
+    fixable: 'code',
     schema: []
   },
   create(context) {
+    const sourceCode = context.getSourceCode()
     return {
       ArrowFunctionExpression(node) {
         context.report({
           node,
-          message: 'Unexpected arrow-function expression.'
+          message: 'Unexpected arrow-function expression.',
+          fix(fixer) {
+            const code = sourceCode.getText(node)
+            const hasThis = /this/.test(code)
+            const functionText = toFunctionExpression(node, sourceCode)
+            return fixer.replaceText(node, hasThis ? `${functionText}.bind(this)` : functionText)
+          }
         });
       }
     };

--- a/tests/rules/no-arrow-functions.js
+++ b/tests/rules/no-arrow-functions.js
@@ -6,7 +6,55 @@ module.exports = {
     'var foo = function () {};'
   ],
   invalid: [
-    { code: 'var foo = () => {};', errors: [{ message: 'Unexpected arrow-function expression.' }] },
-    { code: 'var foo = bar => baz;', errors: [{ message: 'Unexpected arrow-function expression.' }] }
+    {
+      code: 'var foo = () => {};',
+      output: 'var foo = function(){};',
+      errors: [{ message: 'Unexpected arrow-function expression.' }]
+    },
+    {
+      code: 'var foo = bar => baz;',
+      output: 'var foo = function(bar){return baz};',
+      errors: [{ message: 'Unexpected arrow-function expression.' }]
+    },
+    {
+      code: 'var foo = (bar) => baz;',
+      output: 'var foo = function(bar){return baz};',
+      errors: [{ message: 'Unexpected arrow-function expression.' }]
+    },
+    {
+      code: 'var foo = ( a,b,  c) => d().e.f',
+      output: 'var foo = function(a,b,  c){return d().e.f}',
+      errors: [{ message: 'Unexpected arrow-function expression.' }]
+    },
+    {
+      code: 'var foo = (a) => this[a]',
+      output: 'var foo = function(a){return this[a]}.bind(this)',
+      errors: [{ message: 'Unexpected arrow-function expression.' }]
+    },
+    {
+      code: 'var foo = (a => this[a])',
+      output: 'var foo = (function(a){return this[a]}.bind(this))',
+      errors: [{ message: 'Unexpected arrow-function expression.' }]
+    },
+    {
+      code: 'var foo = params => ({foo: bar})',
+      output: 'var foo = function(params){return {foo: bar}}',
+      errors: [{ message: 'Unexpected arrow-function expression.' }]
+    },
+    {
+      code: 'var foo = (param1, param2, ...rest) => { statements }',
+      output: 'var foo = function(param1, param2, ...rest){ statements }',
+      errors: [{ message: 'Unexpected arrow-function expression.' }]
+    },
+    {
+      code: 'var foo = (param1 = defaultValue1, param2, paramN = defaultValueN) => { statements }',
+      output: 'var foo = function(param1 = defaultValue1, param2, paramN = defaultValueN){ statements }',
+      errors: [{ message: 'Unexpected arrow-function expression.' }]
+    },
+    {
+      code: 'var f = ([a, b] = [1, 2], {x: c} = {x: a + b}) => a + b + c;',
+      output: 'var f = function([a, b] = [1, 2], {x: c} = {x: a + b}){return a + b + c};',
+      errors: [{ message: 'Unexpected arrow-function expression.' }]
+    }
   ]
 };


### PR DESCRIPTION
This PR makes `es5/no-arrow-functions` fixable.
The autofix transforms arrow-function-expression to function-expression.