### PR TITLE
[update] Make `es5/no-spread` fixable

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ List of supported rules
   - `es5/no-object-super`: Forbid `super`/`super.foo()` calls.
   - `es5/no-rest-parameters`: Forbid [rest parameters](https://babeljs.io/learn-es2015/#ecmascript-2015-features-default-rest-spread).
   - `es5/no-shorthand-properties`: Forbid [shorthand properties](https://babeljs.io/learn-es2015/#ecmascript-2015-features-enhanced-object-literals).
-  - `es5/no-spread`: Forbid [...spread expressions](https://babeljs.io/learn-es2015/#ecmascript-2015-features-default-rest-spread).
+  - `es5/no-spread`:wrench:: Forbid [...spread expressions](https://babeljs.io/learn-es2015/#ecmascript-2015-features-default-rest-spread).
   - `es5/no-template-literals`:wrench:: Forbid [template strings](https://babeljs.io/learn-es2015/#ecmascript-2015-features-template-strings) usage.
   - `es5/no-typeof-symbol`: Forbid `typeof foo === 'symbol'` [checks](https://babeljs.io/learn-es2015/#ecmascript-2015-features-symbols).
   - `es5/no-unicode-regex`: Forbid [Unicode support](https://babeljs.io/learn-es2015/#ecmascript-2015-features-unicode) in RegExp.

--- a/src/rules/no-spread.js
+++ b/src/rules/no-spread.js
@@ -1,18 +1,42 @@
 'use strict';
 
+function arrayExpressionToArrayConcat(node, sourceCode) {
+  const argCodes = node.elements.map((e) => {
+    if (e.type === 'SpreadElement') {
+      return sourceCode.getText(e.argument)
+    }
+    return `[${sourceCode.getText(e)}]`
+  })
+  return `[].concat(${argCodes.join(',')})`
+}
+
 module.exports = {
   meta: {
     docs: {
       description: 'Forbid spread expressions'
     },
+    fixable: 'code',
     schema: []
   },
   create(context) {
+    const sourceCode = context.getSourceCode()
     return {
       SpreadElement(node) {
         context.report({
           node,
-          message: 'Unexpected spread expression.'
+          message: 'Unexpected spread expression.',
+          fix(fixer) {
+            const parent = node.parent
+            if (!parent) {
+              return undefined
+            }
+            if (parent.type === 'ArrayExpression') {
+              return fixer.replaceText(parent, arrayExpressionToArrayConcat(parent, sourceCode))
+            }
+
+            // Doesn't autofix because it becomes an ugly code. (CallExpression | NewExpression)
+            return undefined
+          }
         });
       }
     };

--- a/tests/rules/no-spread.js
+++ b/tests/rules/no-spread.js
@@ -8,9 +8,40 @@ module.exports = {
     'function foo (...args) {}'
   ],
   invalid: [
-    { code: 'foo(...args)', errors: [{ message: 'Unexpected spread expression.' }] },
-    { code: 'foo(a, b, c, ...args)', errors: [{ message: 'Unexpected spread expression.' }] },
-    { code: '[...args]', errors: [{ message: 'Unexpected spread expression.' }] },
-    { code: '[1, ...[2], 3]', errors: [{ message: 'Unexpected spread expression.' }] }
+    {
+      code: 'foo(...args)',
+      output: null,
+      errors: [{ message: 'Unexpected spread expression.' }]
+    },
+    {
+      code: 'foo(a, b, c, ...args)',
+      output: null,
+      errors: [{ message: 'Unexpected spread expression.' }]
+    },
+    {
+      code: '[...args]',
+      output: '[].concat(args)',
+      errors: [{ message: 'Unexpected spread expression.' }]
+    },
+    {
+      code: '[1, ...[2], 3]',
+      output: '[].concat([1],[2],[3])',
+      errors: [{ message: 'Unexpected spread expression.' }]
+    },
+    {
+      code: '[1, ...args, ]',
+      output: '[].concat([1],args)',
+      errors: [{ message: 'Unexpected spread expression.' }]
+    },
+    {
+      code: '["a", ...b(), ...c]',
+      output: '[].concat(["a"],b(),c)',
+      errors: [{ message: 'Unexpected spread expression.' }, { message: 'Unexpected spread expression.' }]
+    },
+    {
+      code: '[...[...args]]',
+      output: '[].concat([...args])',
+      errors: [{ message: 'Unexpected spread expression.' }, { message: 'Unexpected spread expression.' }]
+    }
   ]
 };


### PR DESCRIPTION
This PR makes `es5/no-spread` fixable.
The autofix transforms `[...args]`  to `[].concat(args)`.

CallExpression and NewExpression do not autofix. Because it becomes ugly code