### PR TITLE
[update] Make `es5/no-exponentiation-operator` warn `**=`

### DIFF
--- a/src/rules/no-exponentiation-operator.js
+++ b/src/rules/no-exponentiation-operator.js
@@ -16,6 +16,14 @@ module.exports = {
             message: 'Unexpected exponentiation operator.'
           });
         }
+      },
+      AssignmentExpression(node) {
+        if (node.operator === '**=') {
+          context.report({
+            node,
+            message: 'Unexpected exponentiation operator.'
+          });
+        }
       }
     };
   }

--- a/tests/rules/no-exponentiation-operator.js
+++ b/tests/rules/no-exponentiation-operator.js
@@ -7,6 +7,7 @@ module.exports = {
   ],
   invalid: [
     { code: 'a ** b', errors: [{ message: 'Unexpected exponentiation operator.' }] },
-    { code: 'var foo = a ** b', errors: [{ message: 'Unexpected exponentiation operator.' }] }
+    { code: 'var foo = a ** b', errors: [{ message: 'Unexpected exponentiation operator.' }] },
+    { code: 'a **= b', errors: [{ message: 'Unexpected exponentiation operator.' }] },
   ]
 };


### PR DESCRIPTION
This PR Makes `es5/no-exponentiation-operator` warn `**=` operator