### PR TITLE
[update] Make `es5/no-destructuring` fixable

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ List of supported rules
   - `es5/no-classes`: Forbid [ES2015 classes](https://babeljs.io/learn-es2015/#ecmascript-2015-features-classes).
   - `es5/no-computed-properties`: Forbid [computed properties](https://babeljs.io/learn-es2015/#ecmascript-2015-features-enhanced-object-literals).
   - `es5/no-default-parameters`: Forbid [default parameters](https://babeljs.io/learn-es2015/#ecmascript-2015-features-default-rest-spread).
-  - `es5/no-destructuring`: Forbid [destructuring statements](https://babeljs.io/learn-es2015/#ecmascript-2015-features-destructuring).
+  - `es5/no-destructuring`:wrench:: Forbid [destructuring statements](https://babeljs.io/learn-es2015/#ecmascript-2015-features-destructuring).
   - `es5/no-exponentiation-operator`: Forbid exponentiation operator `a ** b` usage.
   - `es5/no-for-of`: Forbid [`for-of` statements](https://babeljs.io/learn-es2015/#ecmascript-2015-features-iterators-for-of).
   - `es5/no-generators`: Forbid [generators](https://babeljs.io/learn-es2015/#ecmascript-2015-features-generators) usage.

--- a/src/rules/no-destructuring.js
+++ b/src/rules/no-destructuring.js
@@ -1,17 +1,148 @@
 'use strict';
 
+
+function isSimpleAssignmentRight(node) {
+  if (!node) {
+    return false
+  }
+  if (node.type === 'Identifier' || node.type === 'Literal' || node.type === 'ThisExpression') {
+    return true
+  }
+  if (node.type === 'MemberExpression') {
+    return isSimpleAssignmentRight(node.object) && isSimpleAssignmentRight(node.property)
+  }
+  return false
+}
+
+function isSimpleAssignmentLeft(node) {
+  return !!getMapping(node)
+}
+
+function joinMember(object, property) {
+  if (!/^\[/.test(property)) {
+    return `${object}.${property}`
+  } else {
+    return `${object}${property}`
+  }
+}
+
+function getMapping(node) {
+  function putValues(map, name, valueNode) {
+    if (valueNode.type === 'Identifier') {
+      map[name] = valueNode.name
+    } else if (valueNode.type === 'ObjectPattern' || valueNode.type === 'ArrayPattern') {
+      const subMap = getMapping(valueNode)
+      if (!subMap) {
+        return false
+      }
+      for (let k in subMap) {
+        map[joinMember(name, k)] = subMap[k]
+      }
+    } else {
+      return false
+    }
+    return true
+
+  }
+  if (node.type === 'ObjectPattern') {
+    if (!node.properties.length) {
+      return null
+    }
+    const map = {}
+    for (let p of node.properties) {
+      const name = (p.key.type === 'Identifier' && !p.computed) ? p.key.name
+        : p.key.type === 'Literal' ? `[${p.key.raw}]`
+        : null
+      if (!name) {
+        return null
+      }
+      if (!putValues(map, name, p.value)) {
+        return null
+      }
+    }
+    return map
+  } else  if (node.type === 'ArrayPattern') {
+    if (!node.elements.length) {
+      return null
+    }
+    const map = {}
+    for (let i = 0; i < node.elements.length; i++) {
+      const e = node.elements[i]
+      if (!e) {
+        continue
+      }
+      const name = `[${i}]`
+      if (!putValues(map, name, e)) {
+        return null
+      }
+    }
+    return Object.keys(map).length ? map : null
+  }
+  return null
+}
+
+function isSimpleDestructuringAssignment(node) {
+  if (!node) {
+    return false
+  }
+  if (node.type === 'VariableDeclarator') {
+    if (!isSimpleAssignmentRight(node.init)) {
+      return false
+    }
+    if (!isSimpleAssignmentLeft(node.id)) {
+      return false
+    }
+    return true
+  } else if (node.type === 'AssignmentExpression') {
+    if (!isSimpleAssignmentRight(node.right)) {
+      return false
+    }
+    if (!isSimpleAssignmentLeft(node.left)) {
+      return false
+    }
+    return true
+  }
+  return false
+}
+
+function destructuringAssignmentToAssignments(node, sourceCode) {
+  let right
+  let map
+  if (node.type === 'VariableDeclarator') {
+    right = sourceCode.getText(node.init)
+    map = getMapping(node.id)
+  } else if (node.type === 'AssignmentExpression') {
+    right = sourceCode.getText(node.right)
+    map = getMapping(node.left)
+  }
+  const variableDeclarators = []
+  for (let k in map) {
+    variableDeclarators.push(`${map[k]}=${joinMember(right, k)}`)
+  }
+  return variableDeclarators.join(',')
+}
+
 module.exports = {
   meta: {
     docs: {
       description: 'Forbid destructuring'
     },
+    fixable: 'code',
     schema: []
   },
   create(context) {
+    const sourceCode = context.getSourceCode()
     function report(node) {
       context.report({
         node,
-        message: 'Unexpected destructuring.'
+        message: 'Unexpected destructuring.',
+        fix: (fixer) => {
+          const parent = node.parent
+          if (isSimpleDestructuringAssignment(parent)) {
+            return fixer.replaceText(parent, destructuringAssignmentToAssignments(parent, sourceCode))
+          }
+          return undefined
+        }
       });
     }
 

--- a/tests/rules/no-destructuring.js
+++ b/tests/rules/no-destructuring.js
@@ -7,9 +7,132 @@ module.exports = {
     'function foo(bar) {}'
   ],
   invalid: [
-    { code: 'var [ foo ] = [];', errors: [{ message: 'Unexpected destructuring.' }] },
-    { code: 'var { foo } = {};', errors: [{ message: 'Unexpected destructuring.' }] },
-    { code: 'function foo([ bar ]) {}', errors: [{ message: 'Unexpected destructuring.' }] },
-    { code: 'function foo({ bar }) {}', errors: [{ message: 'Unexpected destructuring.' }] }
+    { code: 'var [ foo ] = [];', output: null, errors: [{ message: 'Unexpected destructuring.' }] },
+    { code: 'var { foo } = {};', output: null, errors: [{ message: 'Unexpected destructuring.' }] },
+    { code: 'function foo([ bar ]) {}', output: null, errors: [{ message: 'Unexpected destructuring.' }] },
+    { code: 'function foo({ bar }) {}', output: null, errors: [{ message: 'Unexpected destructuring.' }] },
+    // ObjectPattern 
+    {
+      code: 'var { a } = foo;',
+      output: 'var a=foo.a;',
+      errors: [{ message: 'Unexpected destructuring.' }]
+    },
+    {
+      code: 'let { a, b } = foo;',
+      output: 'let a=foo.a,b=foo.b;',
+      errors: [{ message: 'Unexpected destructuring.' }]
+    },
+    {
+      code: 'var { a: aa, b: bb } = foo, c = d;',
+      output: 'var aa=foo.a,bb=foo.b, c = d;',
+      errors: [{ message: 'Unexpected destructuring.' }]
+    },
+    {
+      code: 'var { a: {a1, a2: aa2} } = foo;',
+      output: 'var a1=foo.a.a1,aa2=foo.a.a2;',
+      errors: [{ message: 'Unexpected destructuring.' }, { message: 'Unexpected destructuring.' }]
+    },
+    {
+      code: 'var { "s-u-b": {1: a, ["b"]: b} } = foo;',
+      output: 'var a=foo["s-u-b"][1],b=foo["s-u-b"]["b"];',
+      errors: [{ message: 'Unexpected destructuring.' }, { message: 'Unexpected destructuring.' }]
+    },
+    {
+      code: '({ a: {a1: aa1} } = foo, { b: {b1: bb1} } = bar);',
+      output: '(aa1=foo.a.a1, bb1=bar.b.b1);',
+      errors: [{ message: 'Unexpected destructuring.' }, { message: 'Unexpected destructuring.' }, { message: 'Unexpected destructuring.' }, { message: 'Unexpected destructuring.' }]
+    },
+    {
+      code: 'var { a, b } = { a:1, b:2 };',
+      output: null,
+      errors: [{ message: 'Unexpected destructuring.' }]
+    },
+    {
+      code: 'var { [a]: a } = foo;',
+      output: null,
+      errors: [{ message: 'Unexpected destructuring.' }]
+    },
+    {
+      code: 'var { a = 1 } = foo;',
+      output: null,
+      errors: [{ message: 'Unexpected destructuring.' }]
+    },
+    {
+      code: 'var { a } = foo.bar().baz;',
+      output: null,
+      errors: [{ message: 'Unexpected destructuring.' }]
+    },
+    {
+      code: '({ a } = foo.bar().baz)',
+      output: null,
+      errors: [{ message: 'Unexpected destructuring.' }]
+    },
+    // ArrayPattern
+    {
+      code: 'var [ a ] = foo;',
+      output: 'var a=foo[0];',
+      errors: [{ message: 'Unexpected destructuring.' }]
+    },
+    {
+      code: 'const [ a, b ] = foo;',
+      output: 'const a=foo[0],b=foo[1];',
+      errors: [{ message: 'Unexpected destructuring.' }]
+    },
+    {
+      code: 'var [,, a,, b ] = foo;',
+      output: 'var a=foo[2],b=foo[4];',
+      errors: [{ message: 'Unexpected destructuring.' }]
+    },
+    {
+      code: '([ a ] = foo);',
+      output: '(a=foo[0]);',
+      errors: [{ message: 'Unexpected destructuring.' }]
+    },
+    {
+      code: 'var [ a, b ] = [ 1, 2 ];',
+      output: null,
+      errors: [{ message: 'Unexpected destructuring.' }]
+    },
+    {
+      code: 'var [ ,,, ] = foo;',
+      output: null,
+      errors: [{ message: 'Unexpected destructuring.' }]
+    },
+    {
+      code: 'var [ a = 1 ] = foo;',
+      output: null,
+      errors: [{ message: 'Unexpected destructuring.' }]
+    },
+    {
+      code: 'var [ a ] = foo.bar().baz;',
+      output: null,
+      errors: [{ message: 'Unexpected destructuring.' }]
+    },
+    {
+      code: '([ a ] = foo.bar().baz)',
+      output: null,
+      errors: [{ message: 'Unexpected destructuring.' }]
+    },
+    // mix
+    {
+      code: 'var [{a1:aa1}] = foo;',
+      output: 'var aa1=foo[0].a1;',
+      errors: [{ message: 'Unexpected destructuring.' }, { message: 'Unexpected destructuring.' }]
+    },
+    {
+      code: 'var {a : [a1]} = foo;',
+      output: 'var a1=foo.a[0];',
+      errors: [{ message: 'Unexpected destructuring.' }, { message: 'Unexpected destructuring.' }]
+    },
+    {
+      code: 'var [{a1:aa1 = 1}] = foo;',
+      output: null,
+      errors: [{ message: 'Unexpected destructuring.' }, { message: 'Unexpected destructuring.' }]
+    },
+    {
+      code: 'var {a : [a1 = 1]} = foo;',
+      output: null,
+      errors: [{ message: 'Unexpected destructuring.' }, { message: 'Unexpected destructuring.' }]
+    },
   ]
 };


### PR DESCRIPTION
This PR makes `es5/no-destructuring` fixable.
The autofix transforms `let {a} = foo` to `let a = foo.a`