### PR TITLE
[New] Add `es5/no-unicode-code-point-escape` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ List of supported rules
   - `es5/no-spread`: Forbid [...spread expressions](https://babeljs.io/learn-es2015/#ecmascript-2015-features-default-rest-spread).
   - `es5/no-template-literals`:wrench:: Forbid [template strings](https://babeljs.io/learn-es2015/#ecmascript-2015-features-template-strings) usage.
   - `es5/no-typeof-symbol`: Forbid `typeof foo === 'symbol'` [checks](https://babeljs.io/learn-es2015/#ecmascript-2015-features-symbols).
+  - `es5/no-unicode-code-point-escape`:wrench:: Forbid [Unicode support](https://babeljs.io/learn-es2015/#unicode) in code point escape.
   - `es5/no-unicode-regex`: Forbid [Unicode support](https://babeljs.io/learn-es2015/#ecmascript-2015-features-unicode) in RegExp.
 
 License

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ module.exports = {
         'es5/no-spread': 2,
         'es5/no-template-literals': 2,
         'es5/no-typeof-symbol': 2,
+        'es5/no-unicode-code-point-escape': 2,
         'es5/no-unicode-regex': 2
       }
     },
@@ -55,6 +56,7 @@ module.exports = {
     'no-spread': require('./rules/no-spread'),
     'no-template-literals': require('./rules/no-template-literals'),
     'no-typeof-symbol': require('./rules/no-typeof-symbol'),
+    'no-unicode-code-point-escape': require('./rules/no-unicode-code-point-escape'),
     'no-unicode-regex': require('./rules/no-unicode-regex')
   }
 };

--- a/src/rules/no-unicode-code-point-escape.js
+++ b/src/rules/no-unicode-code-point-escape.js
@@ -1,0 +1,87 @@
+'use strict';
+
+function findUnicodeCodePointEscapes(s, start) {
+  const regex = /\\u\{([0-9a-fA-F]+)\}/g
+  let r
+  const result = []
+  while ((r = regex.exec(s))) {
+    result.push({
+      codePoint: r[1],
+      range: [start + r.index, start + regex.lastIndex]
+    })
+  }
+  return result
+}
+function toHex(num) {
+  return ('0000' + num.toString(16).toUpperCase()).substr(-4)
+}
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Forbid unicode code point escape.'
+    },
+    fixable: 'code',
+    schema: []
+  },
+  create(context) {
+    const sourceCode = context.getSourceCode()
+    function report(node, targets) {
+      targets.forEach((target) => {
+        const {range, codePoint} = target
+        context.report({
+          node,
+          loc: {
+            start: sourceCode.getLocFromIndex(range[0]),
+            end: sourceCode.getLocFromIndex(range[1]),
+          },
+          message: 'Unexpected Unicode code point escape. {{codePoint}}',
+          data: {
+            codePoint: `\\u{${codePoint}}`
+          },
+          fix(fixer) {
+            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCodePoint
+            let code = Number('0x' + codePoint)
+            if (
+              !isFinite(code) ||       // `NaN`, `+Infinity`, or `-Infinity`
+              code < 0 ||              // not a valid Unicode code point
+              code > 0x10FFFF ||       // not a valid Unicode code point
+              Math.floor(code) != code // not an integer
+            ) {
+              return undefined
+            }
+            let replacement
+            if (code <= 0xFFFF) { // BMP code point
+              replacement = toHex(code)
+            } else { // Astral code point; split in surrogate halves
+              // http://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
+              code -= 0x10000;
+              const highSurrogate = (code >> 10) + 0xD800;
+              const lowSurrogate = (code % 0x400) + 0xDC00;
+              replacement = `${toHex(highSurrogate)}\\u${toHex(lowSurrogate)}`
+            }
+            return fixer.replaceTextRange([range[0] + 2, range[1]], replacement)
+          }
+        })
+      })
+    }
+    return {
+      Literal(node) {
+        if (typeof node.value === 'string') {
+          const targets = findUnicodeCodePointEscapes(node.raw, node.start)
+          report(node, targets)
+        } else if (node.regex) {
+          const targets = findUnicodeCodePointEscapes(node.raw, node.start)
+          report(node, targets)
+        }
+      },
+      TemplateLiteral(node) {
+        node.quasis.forEach((q) => {
+          const targets = findUnicodeCodePointEscapes(q.value.raw, q.start)
+          report(q, targets)
+        })
+      },
+
+    };
+  }
+};

--- a/tests/rules/no-unicode-code-point-escape.js
+++ b/tests/rules/no-unicode-code-point-escape.js
@@ -45,6 +45,25 @@ module.exports = {
     },
     {
       code: `
+var o = {
+  '\\u{20BB7}': '𠮷'
+}
+`,
+      output: `
+var o = {
+  '\\uD842\\uDFB7': '𠮷'
+}
+`,
+      errors: [
+        {
+          message: 'Unexpected Unicode code point escape. \\u{20BB7}',
+          column: 4,
+          line: 3,
+        }
+      ]
+    },
+    {
+      code: `
 a=\`\${a}\\u{D842}\\u{DFB7}\`
 b="\\u{20BB7}"
 c=/\\u{20BB7}/g

--- a/tests/rules/no-unicode-code-point-escape.js
+++ b/tests/rules/no-unicode-code-point-escape.js
@@ -1,0 +1,93 @@
+'use strict';
+
+module.exports = {
+  valid: [
+    '"𠮷"',
+    '"\\uD842\\uDFB7"',
+    '`𠮷`',
+    '`\\uD842\\uDFB7`',
+    '/𠮷/g',
+    '/\\uD842\\uDFB7/g',
+  ],
+  invalid: [
+    {
+      code: '"\\u{20BB7}"',
+      output: '"\\uD842\\uDFB7"',
+      errors: [
+        {
+          message: 'Unexpected Unicode code point escape. \\u{20BB7}',
+          column: 2,
+          line: 1,
+        }
+      ]
+    },
+    {
+      code: '`\\u{20BB7}`',
+      output: '`\\uD842\\uDFB7`',
+      errors: [
+        {
+          message: 'Unexpected Unicode code point escape. \\u{20BB7}',
+          column: 2,
+          line: 1,
+        }
+      ]
+    },
+    {
+      code: '/\\u{20BB7}/g',
+      output: '/\\uD842\\uDFB7/g',
+      errors: [
+        {
+          message: 'Unexpected Unicode code point escape. \\u{20BB7}',
+          column: 2,
+          line: 1,
+        }
+      ]
+    },
+    {
+      code: `
+a=\`\${a}\\u{D842}\\u{DFB7}\`
+b="\\u{20BB7}"
+c=/\\u{20BB7}/g
+`,
+      output: `
+a=\`\${a}\\uD842\\uDFB7\`
+b="\\uD842\\uDFB7"
+c=/\\uD842\\uDFB7/g
+`,
+      errors: [
+        {
+          message: 'Unexpected Unicode code point escape. \\u{D842}',
+          line: 2,
+          column: 8,
+          nodeType: 'TemplateElement',
+          endLine: 2,
+          endColumn: 16,
+        },
+        {
+          message: 'Unexpected Unicode code point escape. \\u{DFB7}',
+          line: 2,
+          column: 16,
+          nodeType: 'TemplateElement',
+          endLine: 2,
+          endColumn: 24,
+        },
+        {
+          message: 'Unexpected Unicode code point escape. \\u{20BB7}',
+          line: 3,
+          column: 4,
+          nodeType: 'Literal',
+          endLine: 3,
+          endColumn: 13,
+        },
+        {
+          message: 'Unexpected Unicode code point escape. \\u{20BB7}',
+          line: 4,
+          column: 4,
+          nodeType: 'Literal',
+          endLine: 4,
+          endColumn: 13,
+        },
+      ]
+    }
+  ]
+};


### PR DESCRIPTION
This PR adds `es5/no-unicode-code-point-escape` rule.
This rule warns forbid Unicode code point escape.