### PR TITLE
[New] Add `es5/no-binary-and-octal-literals` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ List of supported rules
 -----------------------
 
   - `es5/no-arrow-functions`: Forbid [arrow-functions](https://babeljs.io/learn-es2015/#ecmascript-2015-features-arrows-and-lexical-this).
+  - `es5/no-binary-and-octal-literals`: Forbid [binary and octal literals](https://babeljs.io/learn-es2015/#binary-and-octal-literals).
   - `es5/no-block-scoping`: Forbid `let` and `const` declarations. You can enable them using options: `"es5/no-block-scoping": ["error", { "let": true }]`
   - `es5/no-classes`: Forbid [ES2015 classes](https://babeljs.io/learn-es2015/#ecmascript-2015-features-classes).
   - `es5/no-computed-properties`: Forbid [computed properties](https://babeljs.io/learn-es2015/#ecmascript-2015-features-enhanced-object-literals).

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ List of supported rules
 -----------------------
 
   - `es5/no-arrow-functions`: Forbid [arrow-functions](https://babeljs.io/learn-es2015/#ecmascript-2015-features-arrows-and-lexical-this).
-  - `es5/no-binary-and-octal-literals`: Forbid [binary and octal literals](https://babeljs.io/learn-es2015/#binary-and-octal-literals).
+  - `es5/no-binary-and-octal-literals`:wrench:: Forbid [binary and octal literals](https://babeljs.io/learn-es2015/#binary-and-octal-literals).
   - `es5/no-block-scoping`: Forbid `let` and `const` declarations. You can enable them using options: `"es5/no-block-scoping": ["error", { "let": true }]`
   - `es5/no-classes`: Forbid [ES2015 classes](https://babeljs.io/learn-es2015/#ecmascript-2015-features-classes).
   - `es5/no-computed-properties`: Forbid [computed properties](https://babeljs.io/learn-es2015/#ecmascript-2015-features-enhanced-object-literals).

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ module.exports = {
       ],
       rules: {
         'es5/no-arrow-functions': 2,
+        'es5/no-binary-and-octal-literals': 2,
         'es5/no-block-scoping': 2,
         'es5/no-classes': 2,
         'es5/no-computed-properties': 2,
@@ -38,6 +39,7 @@ module.exports = {
   },
   rules: {
     'no-arrow-functions': require('./rules/no-arrow-functions'),
+    'no-binary-and-octal-literals': require('./rules/no-binary-and-octal-literals'),
     'no-block-scoping': require('./rules/no-block-scoping'),
     'no-classes': require('./rules/no-classes'),
     'no-computed-properties': require('./rules/no-computed-properties'),

--- a/src/rules/no-binary-and-octal-literals.js
+++ b/src/rules/no-binary-and-octal-literals.js
@@ -1,0 +1,36 @@
+'use strict';
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Forbid Binary and Octal literals.'
+    },
+    fixable: 'code',
+    schema: []
+  },
+  create(context) {
+    function report(node, phrase) {
+      context.report({
+        node,
+        message: 'Unexpected {{phrase}} literal.',
+        data: {
+          phrase
+        },
+        fix(fixer) {
+          return fixer.replaceText(node, node.value)
+        }
+      })
+    }
+    return {
+      Literal(node) {
+        if (typeof node.value === 'number') {
+          if (/^0b/i.test(node.raw)) {
+            report(node, 'Binary')
+          } else if (/^0o/i.test(node.raw)) {
+            report(node, 'Octal')
+          }
+        }
+      },
+    };
+  }
+};

--- a/tests/rules/no-binary-and-octal-literals.js
+++ b/tests/rules/no-binary-and-octal-literals.js
@@ -1,0 +1,74 @@
+'use strict';
+
+module.exports = {
+  valid: [
+    `
+var FLT_SIGNBIT  = 2147483648;
+var FLT_EXPONENT = 2139095040;
+var FLT_MANTISSA = 8388607;
+    `,
+  ],
+  invalid: [
+    {
+      code: `
+var FLT_SIGNBIT  = 0b10000000000000000000000000000000; // 2147483648
+var FLT_EXPONENT = 0b01111111100000000000000000000000; // 2139095040
+var FLT_MANTISSA = 0B00000000011111111111111111111111; // 8388607
+      `,
+      output: `
+var FLT_SIGNBIT  = 2147483648; // 2147483648
+var FLT_EXPONENT = 2139095040; // 2139095040
+var FLT_MANTISSA = 8388607; // 8388607
+      `,
+      errors: [
+        {
+          message: 'Unexpected Binary literal.',
+          line: 2,
+          column: 20,
+          endLine: 2,
+          endColumn: 54,
+        },
+        {
+          message: 'Unexpected Binary literal.',
+          line: 3,
+          column: 20,
+          endLine: 3,
+          endColumn: 54,
+        },
+        {
+          message: 'Unexpected Binary literal.',
+          line: 4,
+          column: 20,
+          endLine: 4,
+          endColumn: 54,
+        }
+      ]
+    },
+    {
+      code: `
+var n = 0O755; // 493
+var m = 0o644; // 420
+      `,
+      output: `
+var n = 493; // 493
+var m = 420; // 420
+      `,
+      errors: [
+        {
+          message: 'Unexpected Octal literal.',
+          line: 2,
+          column: 9,
+          endLine: 2,
+          endColumn: 14,
+        },
+        {
+          message: 'Unexpected Octal literal.',
+          line: 3,
+          column: 9,
+          endLine: 3,
+          endColumn: 14,
+        } 
+      ]
+    },
+  ]
+};


### PR DESCRIPTION
This PR adds `es5/no-binary-and-octal-literals` rule.
This rule warns forbid Binary and Octal literals.