### PR TITLE
docs: update links to babel docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,25 +64,25 @@ Available presets:
 List of supported rules
 -----------------------
 
-  - `es5/no-arrow-functions`:wrench:: Forbid [arrow-functions](https://babeljs.io/learn-es2015/#ecmascript-2015-features-arrows-and-lexical-this).
+  - `es5/no-arrow-functions`:wrench:: Forbid [arrow-functions](https://babeljs.io/learn-es2015/#arrows-and-lexical-this).
   - `es5/no-binary-and-octal-literals`:wrench:: Forbid [binary and octal literals](https://babeljs.io/learn-es2015/#binary-and-octal-literals).
   - `es5/no-block-scoping`: Forbid `let` and `const` declarations. You can enable them using options: `"es5/no-block-scoping": ["error", { "let": true }]`
-  - `es5/no-classes`: Forbid [ES2015 classes](https://babeljs.io/learn-es2015/#ecmascript-2015-features-classes).
-  - `es5/no-computed-properties`: Forbid [computed properties](https://babeljs.io/learn-es2015/#ecmascript-2015-features-enhanced-object-literals).
-  - `es5/no-default-parameters`: Forbid [default parameters](https://babeljs.io/learn-es2015/#ecmascript-2015-features-default-rest-spread).
-  - `es5/no-destructuring`:wrench:: Forbid [destructuring statements](https://babeljs.io/learn-es2015/#ecmascript-2015-features-destructuring).
+  - `es5/no-classes`: Forbid [ES2015 classes](https://babeljs.io/learn-es2015/#classes).
+  - `es5/no-computed-properties`: Forbid [computed properties](https://babeljs.io/learn-es2015/#enhanced-object-literals).
+  - `es5/no-default-parameters`: Forbid [default parameters](https://babeljs.io/learn-es2015/#default--rest--spread).
+  - `es5/no-destructuring`:wrench:: Forbid [destructuring statements](https://babeljs.io/learn-es2015/#destructuring).
   - `es5/no-exponentiation-operator`: Forbid exponentiation operator `a ** b` usage.
-  - `es5/no-for-of`: Forbid [`for-of` statements](https://babeljs.io/learn-es2015/#ecmascript-2015-features-iterators-for-of).
-  - `es5/no-generators`: Forbid [generators](https://babeljs.io/learn-es2015/#ecmascript-2015-features-generators) usage.
-  - `es5/no-modules`: Forbid ES2015 [modules](https://babeljs.io/learn-es2015/#ecmascript-2015-features-modules) usage.
+  - `es5/no-for-of`: Forbid [`for-of` statements](https://babeljs.io/learn-es2015/#iterators--forof).
+  - `es5/no-generators`: Forbid [generators](https://babeljs.io/learn-es2015/#generators) usage.
+  - `es5/no-modules`: Forbid ES2015 [modules](https://babeljs.io/learn-es2015/#modules) usage.
   - `es5/no-object-super`: Forbid `super`/`super.foo()` calls.
-  - `es5/no-rest-parameters`: Forbid [rest parameters](https://babeljs.io/learn-es2015/#ecmascript-2015-features-default-rest-spread).
-  - `es5/no-shorthand-properties`: Forbid [shorthand properties](https://babeljs.io/learn-es2015/#ecmascript-2015-features-enhanced-object-literals).
-  - `es5/no-spread`:wrench:: Forbid [...spread expressions](https://babeljs.io/learn-es2015/#ecmascript-2015-features-default-rest-spread).
-  - `es5/no-template-literals`:wrench:: Forbid [template strings](https://babeljs.io/learn-es2015/#ecmascript-2015-features-template-strings) usage.
-  - `es5/no-typeof-symbol`: Forbid `typeof foo === 'symbol'` [checks](https://babeljs.io/learn-es2015/#ecmascript-2015-features-symbols).
+  - `es5/no-rest-parameters`: Forbid [rest parameters](https://babeljs.io/learn-es2015/#default--rest--spread).
+  - `es5/no-shorthand-properties`: Forbid [shorthand properties](https://babeljs.io/learn-es2015/#enhanced-object-literals).
+  - `es5/no-spread`:wrench:: Forbid [...spread expressions](https://babeljs.io/learn-es2015/#default--rest--spread).
+  - `es5/no-template-literals`:wrench:: Forbid [template strings](https://babeljs.io/learn-es2015/#template-strings) usage.
+  - `es5/no-typeof-symbol`: Forbid `typeof foo === 'symbol'` [checks](https://babeljs.io/learn-es2015/#symbols).
   - `es5/no-unicode-code-point-escape`:wrench:: Forbid [Unicode support](https://babeljs.io/learn-es2015/#unicode) in code point escape.
-  - `es5/no-unicode-regex`: Forbid [Unicode support](https://babeljs.io/learn-es2015/#ecmascript-2015-features-unicode) in RegExp.
+  - `es5/no-unicode-regex`: Forbid [Unicode support](https://babeljs.io/learn-es2015/#unicode) in RegExp.
 
 License
 -------


### PR DESCRIPTION
Some of the links to learning ES2015 have changed on Babel's website, so
this commit addresses some outdated links.