### PR TITLE
refactor: improve speed of es6 method rules

### DIFF
--- a/src/rules/no-es6-methods.js
+++ b/src/rules/no-es6-methods.js
@@ -1,5 +1,23 @@
 'use strict';
 
+const es6Functions = {
+  // array functions
+  find: true,
+  findIndex: true,
+  copyWithin: true,
+  values: true,
+  fill: true,
+  // string functions
+  startsWith: true,
+  endsWith: true,
+  includes: true,
+  repeat: true
+}
+
+const objectExceptions = {
+  '_': true
+}
+
 module.exports = {
   meta: {
     docs: {
@@ -10,29 +28,9 @@ module.exports = {
   create(context) {
     return {
       CallExpression(node) {
-        const objectExceptions = ['_'];
-        if(node.callee && node.callee.property && objectExceptions.indexOf(node.callee.object.name) === -1) {
+        if (node.callee && node.callee.property && !objectExceptions[node.callee.object.name]) {
           const functionName = node.callee.property.name;
-
-          const es6ArrayFunctions = [
-            'find',
-            'findIndex',
-            'copyWithin',
-            'values',
-            'fill'
-          ];
-          const es6StringFunctions = [
-            'startsWith',
-            'endsWith',
-            'includes',
-            'repeat'
-          ];
-
-          const es6Functions = [].concat(
-            es6ArrayFunctions,
-            es6StringFunctions
-          );
-          if(es6Functions.indexOf(functionName) > -1) {
+          if (es6Functions[functionName]) {
             context.report({
               node: node.callee.property,
               message: 'ES6 methods not allowed: ' + functionName

--- a/src/rules/no-es6-static-methods.js
+++ b/src/rules/no-es6-static-methods.js
@@ -1,5 +1,19 @@
 'use strict';
 
+const es6StaticFunctions = {
+  'Array.from': true,
+  'Array.of': true,
+  'Math.acosh': true,
+  'Math.hypot': true,
+  'Math.trunc': true,
+  'Math.imul': true,
+  'Math.sign': true,
+  'Number.isNaN': true,
+  'Number.isFinite': true,
+  'Number.isSafeInteger': true,
+  'Object.assign': true,
+}
+
 module.exports = {
   meta: {
     docs: {
@@ -10,22 +24,9 @@ module.exports = {
   create(context) {
     return {
       CallExpression(node) {
-        if(node.callee && node.callee.property && node.callee.object) {
+        if (node.callee && node.callee.property && node.callee.object) {
           const functionName = node.callee.object.name + '.' + node.callee.property.name;
-          const es6StaticFunctions = [
-            'Array.from',
-            'Array.of',
-            'Math.acosh',
-            'Math.hypot',
-            'Math.trunc',
-            'Math.imul',
-            'Math.sign',
-            'Number.isNaN',
-            'Number.isFinite',
-            'Number.isSafeInteger',
-            'Object.assign',
-          ];
-          if(es6StaticFunctions.indexOf(functionName) > -1) {
+          if (es6StaticFunctions[functionName]) {
             context.report({
               node: node.callee.property,
               message: 'ES6 static methods not allowed: ' + functionName


### PR DESCRIPTION
This is a minor refactor / speed improvement. In regards to [Big O notation](https://rob-bell.net/2009/06/a-beginners-guide-to-big-o-notation/), looking up an ES6 method or ES6 static method will now have O(1) time complexity, as opposed to the previous O(n) time complexity. The hashmaps are created when the rule module is created instead of creating/concatenating an array every time the `no-es6-methods` rule wants to check a function name, for example, which is also a small speed improvement. 