### PR TITLE
[add] option exceptMethods to no-es6-static-methods

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,7 @@
     "ecmaVersion": 2015
   },
   "env": {
-    "node": true
+    "node": true,
+    "es6": true
   }
 }

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ List of supported rules
 -----------------------
 
   - `es5/no-es6-methods` Forbid ES2015 [methods](http://babeljs.io/learn-es2015/#math--number--string--object-apis) for `Array` and `String`
-  - `es5/no-es6-static-methods` Forbid ES2015 [static methods](http://babeljs.io/learn-es2015/#math--number--string--object-apis) for `Array`, `Math`, `Number`, and `Object`
+  - `es5/no-es6-static-methods` Forbid ES2015 [static methods](http://babeljs.io/learn-es2015/#math--number--string--object-apis) for `Array`, `Math`, `Number`, and `Object`. You can enable specific functions: `"es5/no-es6-static-methods": ["error", { exceptMethods: ["Math.imul"] }]`
   - `es5/no-arrow-functions`:wrench:: Forbid [arrow-functions](https://babeljs.io/learn-es2015/#ecmascript-2015-features-arrows-and-lexical-this).
   - `es5/no-binary-and-octal-literals`:wrench:: Forbid [binary and octal literals](https://babeljs.io/learn-es2015/#binary-and-octal-literals).
   - `es5/no-block-scoping`: Forbid `let` and `const` declarations. You can enable them using options: `"es5/no-block-scoping": ["error", { "let": true }]`

--- a/tests/rules/no-es6-static-methods.js
+++ b/tests/rules/no-es6-static-methods.js
@@ -3,10 +3,12 @@
 module.exports = {
   valid: [
     'Object.create()',
-    'isNaN()'
+    'isNaN()',
+    { code: 'Math.imul()', options: [{ exceptMethods: ['Math.imul'] }] }
   ],
   invalid: [
     { code: 'Object.assign()', errors: [{ message: 'ES6 static methods not allowed: Object.assign' }] },
-    { code: 'Number.isNaN()', errors: [{ message: 'ES6 static methods not allowed: Number.isNaN' }] }
+    { code: 'Number.isNaN()', errors: [{ message: 'ES6 static methods not allowed: Number.isNaN' }] },
+    { code: 'Math.imul()', options: [{ exceptMethods: ['Number.isNaN'] }], errors: [{ message: 'ES6 static methods not allowed: Math.imul' }] }
   ]
 };


### PR DESCRIPTION
Options for rule `no-es6-static-methods` which allow use specific method. Some methods can be shimmed with polyfills or replace function which used from es6 to not used from es6 set (bn.js case: https://github.com/indutny/bn.js/blob/f953de2a4040852c8948f6ac36e501b092379292/lib/bn.js#L1635-L1638).