### PR TITLE
Extend no-es6-methods to detect common jQuery and Lodash uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ESLint plugin for ES5 users.
 Why?
 ----
 
-Sometimes someone doesn't want or can't to use Babel.
+Sometimes someone doesn't want to or can't use Babel.
 Even if you support modern browsers or node.js, JS engines have bugs
 like broken [block-scoping](http://stackoverflow.com/q/32665347).
 Maybe you only want to forbid usage of `for-of` in your project.

--- a/src/rules/no-es6-methods.js
+++ b/src/rules/no-es6-methods.js
@@ -1,5 +1,13 @@
 'use strict';
 
+function isPermitted(callee) {
+  const objectExceptions = ['_'];
+  if(objectExceptions.indexOf(callee.object.name) === -1) {
+    return true;
+  }
+  return false;
+}
+
 module.exports = {
   meta: {
     docs: {
@@ -10,34 +18,32 @@ module.exports = {
   create(context) {
     return {
       CallExpression(node) {
-        const objectExceptions = ['_'];
-        if(node.callee && node.callee.property && objectExceptions.indexOf(node.callee.object.name) === -1) {
-          const functionName = node.callee.property.name;
-
-          const es6ArrayFunctions = [
-            'find',
-            'findIndex',
-            'copyWithin',
-            'values',
-            'fill'
-          ];
-          const es6StringFunctions = [
-            'startsWith',
-            'endsWith',
-            'includes',
-            'repeat'
-          ];
-
-          const es6Functions = [].concat(
-            es6ArrayFunctions,
-            es6StringFunctions
-          );
-          if(es6Functions.indexOf(functionName) > -1) {
-            context.report({
-              node: node.callee.property,
-              message: 'ES6 methods not allowed: ' + functionName
-            });
-          }
+        if(!node.callee || !node.callee.property || isPermitted(node.callee)) {
+          return;
+        }
+        const functionName = node.callee.property.name;
+        const es6ArrayFunctions = [
+          'find',
+          'findIndex',
+          'copyWithin',
+          'values',
+          'fill'
+        ];
+        const es6StringFunctions = [
+          'startsWith',
+          'endsWith',
+          'includes',
+          'repeat'
+        ];
+        const es6Functions = [].concat(
+          es6ArrayFunctions,
+          es6StringFunctions
+        );
+        if (es6Functions.indexOf(functionName) > -1) {
+          context.report({
+            node: node.callee.property,
+            message: 'ES6 methods not allowed: ' + functionName
+          });
         }
       }
     };

--- a/src/rules/no-es6-methods.js
+++ b/src/rules/no-es6-methods.js
@@ -1,11 +1,34 @@
 'use strict';
 
-function isPermitted(callee) {
-  const objectExceptions = ['_'];
-  if(objectExceptions.indexOf(callee.object.name) === -1) {
+/**
+ * Walks backwards through a chain of callees to get the original.
+ */
+function getOriginalCallee(callee) {
+  while (callee.type === 'MemberExpression' && callee.object.type === 'CallExpression') {
+    callee = callee.object.callee;
+  }
+  return callee;
+}
+
+function isLodash(callee) {
+  // Check for direct calls
+  if(callee.object.name === '_') {
     return true;
   }
+
+  // Check for _.chain
+  const original = getOriginalCallee(callee);
+  if(original.type === 'MemberExpression'
+      && original.object.name === '_'
+      && original.property.name === 'chain') {
+    return true;
+  }
+
   return false;
+}
+
+function isPermitted(callee) {
+  return isLodash(callee);
 }
 
 module.exports = {
@@ -18,7 +41,7 @@ module.exports = {
   create(context) {
     return {
       CallExpression(node) {
-        if(!node.callee || !node.callee.property || isPermitted(node.callee)) {
+        if(!node.callee || !node.callee.property) {
           return;
         }
         const functionName = node.callee.property.name;
@@ -39,7 +62,7 @@ module.exports = {
           es6ArrayFunctions,
           es6StringFunctions
         );
-        if (es6Functions.indexOf(functionName) > -1) {
+        if (es6Functions.indexOf(functionName) > -1 && !isPermitted(node.callee)) {
           context.report({
             node: node.callee.property,
             message: 'ES6 methods not allowed: ' + functionName

--- a/src/rules/no-es6-methods.js
+++ b/src/rules/no-es6-methods.js
@@ -27,8 +27,24 @@ function isLodash(callee) {
   return false;
 }
 
+function isJQuery(callee) {
+  const original = getOriginalCallee(callee);
+
+  if(original.type === 'Identifier' && (original.name === '$' || original.name === 'jQuery')) {
+    return true;
+  }
+
+  // Support the popular convention of prefixing a variable with $ to show that
+  // it refers to a jQuery object: https://stackoverflow.com/a/553734
+  if(original.type === 'MemberExpression' && original.object.type === 'Identifier' && original.object.name[0] === '$') {
+    return true;
+  }
+
+  return false;
+}
+
 function isPermitted(callee) {
-  return isLodash(callee);
+  return isLodash(callee) || isJQuery(callee);
 }
 
 module.exports = {

--- a/tests/rules/no-es6-methods.js
+++ b/tests/rules/no-es6-methods.js
@@ -5,7 +5,10 @@ module.exports = {
     'test.testMethod()',
     'test.otherTestMethod()',
     '_.find([1, 2, 3])',
-    '_.chain([1, 2, 3]).reverse().find().value()'
+    '_.chain([1, 2, 3]).reverse().find().value()',
+    '$("#myDiv").find(".child")',
+    'jQuery("#myDiv").parent().find(".child")',
+    '$myForm.find(".child")'
   ],
   invalid: [
     { code: '[1, 2, 3].find(x => x == 3);', errors: [{ message: 'ES6 methods not allowed: find' }] },

--- a/tests/rules/no-es6-methods.js
+++ b/tests/rules/no-es6-methods.js
@@ -3,7 +3,8 @@
 module.exports = {
   valid: [
     'test.testMethod()',
-    'test.otherTestMethod()'
+    'test.otherTestMethod()',
+    '_.find([1, 2, 3])'
   ],
   invalid: [
     { code: '[1, 2, 3].find(x => x == 3);', errors: [{ message: 'ES6 methods not allowed: find' }] },

--- a/tests/rules/no-es6-methods.js
+++ b/tests/rules/no-es6-methods.js
@@ -4,7 +4,8 @@ module.exports = {
   valid: [
     'test.testMethod()',
     'test.otherTestMethod()',
-    '_.find([1, 2, 3])'
+    '_.find([1, 2, 3])',
+    '_.chain([1, 2, 3]).reverse().find().value()'
   ],
   invalid: [
     { code: '[1, 2, 3].find(x => x == 3);', errors: [{ message: 'ES6 methods not allowed: find' }] },


### PR DESCRIPTION
As discussed in #12, eslint-plugin-es5 flags uses of jQuery and Lodash methods. It's not practical to fully solve this problem without full-fledged type analysis, but it seems straightforward to catch some common scenarios. Here's my attempt at doing so. Feedback welcome.