### PR TITLE
Added exceptMethods and additionalMethods options to no-es6-methods

### DIFF
--- a/tests/rules/no-es6-methods.js
+++ b/tests/rules/no-es6-methods.js
@@ -8,10 +8,19 @@ module.exports = {
     '_.chain([1, 2, 3]).reverse().find().value()',
     '$("#myDiv").find(".child")',
     'jQuery("#myDiv").parent().find(".child")',
-    '$myForm.find(".child")'
+    '$myForm.find(".child")',
+    '[[1, 2], [3, 4]].flat()',
+    { code: 'jqVariable.find(x => x == 3);', options: [{ exceptMethods: ['find'] }] },
+    { code: 'a.includes("123");', options: [{ exceptMethods: ['includes'] }] },
   ],
   invalid: [
     { code: '[1, 2, 3].find(x => x == 3);', errors: [{ message: 'ES6 methods not allowed: find' }] },
-    { code: '[0, 0, 0].fill(7, 1);', errors: [{ message: 'ES6 methods not allowed: fill' }] }
+    { code: '[0, 0, 0].fill(7, 1);', errors: [{ message: 'ES6 methods not allowed: fill' }] },
+    { code: '[1, 2, 3].filter(x => x !== 3);',
+      options: [{ exceptMethods: ['map'], additionalMethods: ['filter'] }],
+      errors: [{ message: 'ES6 methods not allowed: filter' }] },
+    { code: '[[1, 2], [3, 4]].flat()',
+      options: [{ exceptMethods: ['map'], additionalMethods: ['flat'] }],
+      errors: [{ message: 'ES6 methods not allowed: flat' }] }
   ]
 };


### PR DESCRIPTION
This PR adds the ability to ban extra array or string functions (like flat, filter, etc).
And also, the ability to exclude some methods, like find, for example, if you don't want to see errors or warnings for your jQuery variables that don't have a name including $ sign (another way to avoid https://github.com/nkt/eslint-plugin-es5/issues/12).